### PR TITLE
Configurable Prefix

### DIFF
--- a/src/main/java/github/jaffe2718/mcmti/client/event/EventHandler.java
+++ b/src/main/java/github/jaffe2718/mcmti/client/event/EventHandler.java
@@ -110,7 +110,7 @@ public class EventHandler {
                 microphoneHandler != null &&                                   // If the microphone initialization is successful
                 !lastResult.equals("")) {                                      // If the recognized text is not empty
             // Send the recognized text to the server as a chat message automatically
-            client.player.networkHandler.sendChatMessage("⌈Speech Input⌋ " + lastResult);
+            client.player.networkHandler.sendChatMessage(ConfigUI.prefix + " " + lastResult);
             client.player.sendMessage(Text.of("§aMessage Sent"), true);
             lastResult = "";                                                   // Clear the recognized text
         }

--- a/src/main/java/github/jaffe2718/mcmti/config/ConfigUI.java
+++ b/src/main/java/github/jaffe2718/mcmti/config/ConfigUI.java
@@ -30,6 +30,13 @@ public class ConfigUI extends MidnightConfig{
     @Entry(min = 8000, max = 48000) public static int sampleRate = 16000;  // The sample rate of the microphone, the default is 16000
 
     /**
+     * The prefix to prepend in front of chat messages.
+     * The default value is "⌈Speech Input⌋".
+     * You can change it to any string you want.
+     */
+    @Entry(width = 300) public static String prefix = "⌈Speech Input⌋";    // The prefix to prepend in front of chat messages
+
+    /**
      * This is a beta feature, it may cause errors.
      * Enable it to fix the encoding error, set this value to true.
      */

--- a/src/main/resources/assets/mcmti/lang/en_us.json
+++ b/src/main/resources/assets/mcmti/lang/en_us.json
@@ -4,6 +4,7 @@
     "mcmti.midnightconfig.acousticModelPath": "absolute path of acoustic model",
     "mcmti.midnightconfig.cacheSize": "audio cache size (unit: Byte)",
     "mcmti.midnightconfig.sampleRate": "audio sample rate (unit: Hz)",
+    "mcmti.midnightconfig.prefix": "prefix of the recognized text",
     "mcmti.midnightconfig.encoding_repair": "error encoding repair (beta)",
     "mcmti.midnightconfig.srcEncoding": "source encoding (beta)",
     "mcmti.midnightconfig.dstEncoding": "destination encoding (beta)",

--- a/src/main/resources/assets/mcmti/lang/zh_cn.json
+++ b/src/main/resources/assets/mcmti/lang/zh_cn.json
@@ -4,6 +4,7 @@
     "mcmti.midnightconfig.acousticModelPath": "声学模型的绝对路径",
     "mcmti.midnightconfig.cacheSize": "录制音频缓存大小（单位Byte）",
     "mcmti.midnightconfig.sampleRate": "录制音频的采样率（单位Hz）",
+    "mcmti.midnightconfig.prefix": "识别文本的前缀",
     "mcmti.midnightconfig.encoding_repair": "是否修复编码（测试版）",
     "mcmti.midnightconfig.srcEncoding": "源编码     （测试版）",
     "mcmti.midnightconfig.dstEncoding": "目标编码    （测试版）",


### PR DESCRIPTION
Made the prefix that is added in front of the recognized text, configurable. Users may now set the prefix in Mod Menu.

![Screenshot of the config UI](https://i.imgur.com/gmdzbzl.png)
![Screenshot in-game](https://i.imgur.com/rZ5Uh9V.png)