### PR TITLE
Added parkNanos in while-loops

### DIFF
--- a/common/src/main/java/me/jaffe2718/mcmti/event/EventSystem.java
+++ b/common/src/main/java/me/jaffe2718/mcmti/event/EventSystem.java
@@ -85,9 +85,9 @@ public interface EventSystem {
                                 });
                             } else if (vthread != null && vthread.isAlive()) {
                                 player.sendMessage(Text.translatable("message.mcmti.recognizing"), true);
-                            } else {
-                                LockSupport.parkNanos(1000000L);
                             }
+
+                            LockSupport.parkNanos(1000000L);
                         }
                         case RELEASE_KEY_TO_INPUT -> {
                             if (MicrophoneTextInput.RECOGNIZE_KEY.isPressed()) {
@@ -100,9 +100,9 @@ public interface EventSystem {
                                 });
                             } else if (vthread != null && vthread.isAlive()) {
                                 player.sendMessage(Text.translatable("message.mcmti.recognizing"), true);
-                            } else {
-                                LockSupport.parkNanos(1000000L);
                             }
+
+                            LockSupport.parkNanos(1000000L);
                         }
                     }
                 } else {

--- a/common/src/main/java/me/jaffe2718/mcmti/event/EventSystem.java
+++ b/common/src/main/java/me/jaffe2718/mcmti/event/EventSystem.java
@@ -101,6 +101,8 @@ public interface EventSystem {
                             }
                         }
                     }
+
+                    LockSupport.parkNanos(1000000L);
                 } else {
                     LockSupport.parkNanos(10000000L);
                 }

--- a/common/src/main/java/me/jaffe2718/mcmti/event/EventSystem.java
+++ b/common/src/main/java/me/jaffe2718/mcmti/event/EventSystem.java
@@ -85,6 +85,8 @@ public interface EventSystem {
                                 });
                             } else if (vthread != null && vthread.isAlive()) {
                                 player.sendMessage(Text.translatable("message.mcmti.recognizing"), true);
+                            } else {
+                                LockSupport.parkNanos(1000000L);
                             }
                         }
                         case RELEASE_KEY_TO_INPUT -> {
@@ -98,11 +100,11 @@ public interface EventSystem {
                                 });
                             } else if (vthread != null && vthread.isAlive()) {
                                 player.sendMessage(Text.translatable("message.mcmti.recognizing"), true);
+                            } else {
+                                LockSupport.parkNanos(1000000L);
                             }
                         }
                     }
-
-                    LockSupport.parkNanos(1000000L);
                 } else {
                     LockSupport.parkNanos(10000000L);
                 }

--- a/common/src/main/java/me/jaffe2718/mcmti/util/AudioRecorder.java
+++ b/common/src/main/java/me/jaffe2718/mcmti/util/AudioRecorder.java
@@ -12,7 +12,6 @@ import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.ShortBuffer;
-import java.util.concurrent.locks.LockSupport;
 
 public final class AudioRecorder {
     private static final AudioFormat AUDIO_FORMAT = new AudioFormat(16000, 16, 1, true, false);
@@ -75,8 +74,6 @@ public final class AudioRecorder {
             if (read > 0) {
                 dynamicBuffer.write(chunk, 0, read);
             }
-
-            LockSupport.parkNanos(1000000L);
         }
         INSTANCE.line.stop();
         INSTANCE.line.flush();

--- a/common/src/main/java/me/jaffe2718/mcmti/util/AudioRecorder.java
+++ b/common/src/main/java/me/jaffe2718/mcmti/util/AudioRecorder.java
@@ -12,6 +12,7 @@ import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.ShortBuffer;
+import java.util.concurrent.locks.LockSupport;
 
 public final class AudioRecorder {
     private static final AudioFormat AUDIO_FORMAT = new AudioFormat(16000, 16, 1, true, false);
@@ -74,6 +75,8 @@ public final class AudioRecorder {
             if (read > 0) {
                 dynamicBuffer.write(chunk, 0, read);
             }
+
+            LockSupport.parkNanos(1000000L);
         }
         INSTANCE.line.stop();
         INSTANCE.line.flush();


### PR DESCRIPTION
Fixes #13

Current parkNanos is only waiting for Minecraft to become "available" for recording, but when it does, it causes CPU starvation

Check fails when `MinecraftClient.getInstance().currentScreen == null`, thats why
"If I open an inventory, go to chat, or bring up the game menu, the CPU usage drops to normal"
https://github.com/Jaffe2718/Microphone-Text-Input/blob/5ae250fda83576c650b286694282e3f11eb99931/common/src/main/java/me/jaffe2718/mcmti/event/EventSystem.java#L59-L63

I also added parkNanos in AudioRecorder#record while-loop, it can possibly cause the same issue